### PR TITLE
Add ability to create or configure a `ServiceAccount` resource

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 k8s@Home
+   Copyright 2020 pmint93
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.13.1
+version: 0.13.2
 appVersion: v0.36.3
 maintainers:
 - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -94,6 +94,9 @@ The following table lists the configurable parameters of the Metabase chart and 
 | service.internalPort             | Service internal port, should be the same as `listen.port`  | 3000              |
 | service.nodePort                 | Service node port                                           | null              |
 | service.annotations              | Service annotations                                         | {}                |
+| serviceAccount.create            | Specifies whether a service account should be created       | false             |
+| serviceAccount.annotations       | Annotations to add to the service account                   | {}                |
+| serviceAccount.name              | The name of the service account to use                      | null              |
 | ingress.enabled                  | Enable ingress controller resource                          | false             |
 | ingress.hosts                    | Ingress resource hostnames                                  | null              |
 | ingress.path                     | Ingress path                                                | /                 |

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -34,3 +34,14 @@ Return the apiVersion of deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "metabase.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -161,6 +161,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ template "metabase.serviceAccountName" . }}
       volumes:
         {{- if .Values.log4jProperties}}
         - name: config

--- a/charts/metabase/templates/serviceaccount.yaml
+++ b/charts/metabase/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metabase.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -113,6 +113,15 @@ ingress:
 #
 # log4jProperties:
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Add ability to create or configure a `ServiceAccount` resource for the metabase Deployment.

Needed when PodSecurityPolicies (PSP) are in place.