### PR TITLE
Added options to configure MB_COOKIE_SAMESITE

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.13.3
-appVersion: v0.36.3
+version: 0.13.4
+appVersion: v0.39.3
 maintainers:
 - name: pmint93
   email: phamminhthanh69@gmail.com

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                   | controller pods annotations                                 | {}                |
 | podLabels                        | extra pods labels                                           | {}                |
 | image.repository                 | controller container image repository                       | metabase/metabase |
-| image.tag                        | controller container image tag                              | v0.36.3           |
+| image.tag                        | controller container image tag                              | v0.39.3           |
 | image.command                    | controller container image command                          | []                |
 | image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
 | fullnameOverride                 | String to fully override metabase.fullname template         | null              |

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -130,6 +130,10 @@ spec:
           - name: MB_SESSION_COOKIES
             value: {{ .Values.session.sessionCookies | quote }}
           {{- end }}
+          {{- if .Values.session.cookieSameSite }}
+          - name: MB_COOKIE_SAMESITE
+            value: {{ .Values.session.cookieSameSite | quote }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.36.3
+  tag: v0.39.3
   command: []
   pullPolicy: IfNotPresent
 
@@ -68,6 +68,7 @@ emojiLogging: true
 session: {}
   # maxSessionAge:
   # sessionCookies:
+  # cookieSameSite:
 
 livenessProbe:
   initialDelaySeconds: 120


### PR DESCRIPTION
Added the option to configure `MB_COOKIE_SAMESITE` since this is available in current metabase version (v0.39.3).
https://github.com/metabase/metabase/blob/v0.39.3/src/metabase/config.clj#L112-L121
