### PR TITLE
fix: add path type

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.13.4
+version: 0.13.5
 appVersion: v0.39.3
 maintainers:
-- name: pmint93
-  email: phamminhthanh69@gmail.com
+  - name: pmint93
+    email: phamminhthanh69@gmail.com
 home: http://www.metabase.com/
 icon: http://www.metabase.com/images/logo.svg
 sources:
-- https://github.com/metabase/metabase
+  - https://github.com/metabase/metabase

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -101,6 +101,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | ingress.enabled                  | Enable ingress controller resource                          | false             |
 | ingress.hosts                    | Ingress resource hostnames                                  | null              |
 | ingress.path                     | Ingress path                                                | /                 |
+| ingress.pathType                 | Ingress pathType                                            | null              |
 | ingress.labels                   | Ingress labels configuration                                | null              |
 | ingress.annotations              | Ingress annotations configuration                           | {}                |
 | ingress.tls                      | Ingress TLS configuration                                   | null              |

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "metabase.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -26,6 +27,9 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if $ingressPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
When I deployed this with the aws alb ingress controller, I was able to get the main html from the base path but anything under that would be a 404, it looks like if we omit the `pathType` it assumes `ImplementationSpecific` and prevents sub-paths from working, setting `pathType: Prefix` fixed it for me.