### PR TITLE
Fix: use ingress networking.k8s.io/v1beta1 when v1 not available

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.1.0
+version: 1.1.1
 appVersion: v0.39.3
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "metabase.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -38,4 +39,38 @@ spec:
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
   {{- end -}}
+{{- else -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
:question: What
---
Modify the ingress template with conditional based on the cluster version.

:speech_balloon: Why
---
Some versions of k8s like 1.17 [does not have ](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)the `networking.k8s.io/v1` API version available since it was introduced in 1.19.
This is en error while trying to install this chart in a 1.17 cluster :arrow_down: 
```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "networking.k8s.io/v1"
```
This PR aims to introduce backwards compatibility regarding Ingress with older clusters.

:memo: Notes
---
The same command
`helm install metabase . --atomic --dry-run --wait -f values.yaml -f values-custom.yaml`

Executed in a 1.21 cluster, renders...
```
...
apiVersion: networking.k8s.io/v1
...
```
Executed in a 1.17 cluster, renders...
```
...
apiVersion: extensions/v1beta1
...
```

A clear side to side comparison of the templating change

![image](https://user-images.githubusercontent.com/17387387/129752756-d8bc3c10-b362-4631-abce-d178739d7060.png)
