### PR TITLE
Add MB_COLORIZE_LOGS env variable

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.1.1
+version: 1.1.2
 appVersion: v0.39.3
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -81,6 +81,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | password.length                  | Minimum length required for Metabase account's password     | 6                 |
 | timeZone                         | Service time zone                                           | UTC               |
 | emojiLogging                     | Get a funny emoji in service log                            | true              |
+| colorLogging                     | Color log lines. When set to false it will disable log line colors | true       |
 | javaOpts                         | JVM options                                                 | null              |
 | pluginsDirectory                 | A directory with Metabase plugins                           | null              |
 | livenessProbe.initialDelaySeconds | Delay before liveness probe is initiated                   | 120               |

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
           {{- end }}
           - name: MB_EMOJI_IN_LOGS
             value: {{ .Values.emojiLogging | quote }}
+          - name: MB_COLORIZE_LOGS
+            value: {{ .Values.colorLogging | quote }}
           {{- if .Values.siteUrl }}
           - name: MB_SITE_URL
             value: {{ .Values.siteUrl | quote }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -61,6 +61,7 @@ password:
 
 timeZone: UTC
 emojiLogging: true
+colorLogging: true
 # javaOpts:
 # pluginsDirectory:
 # siteUrl:


### PR DESCRIPTION
It could be useful to disable [log colouring](https://www.metabase.com/docs/latest/operations-guide/environment-variables.html#mb_colorize_logs) in case of processing metabase logs by fluentd or so. 