### PR TITLE
Update default metabase image version

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.1.5
-appVersion: v0.39.3
+version: 1.2.0
+appVersion: v0.41.0
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.39.3
+  tag: v0.41.0
   command: []
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Sets the version of the metabase/metabase image to the latest release: https://github.com/metabase/metabase/releases/tag/v0.41.0