### PR TITLE
Metabase: Google Cloud SQL support

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.2.0
+version: 1.3.0
 appVersion: v0.41.0
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -78,6 +78,9 @@ The following table lists the configurable parameters of the Metabase chart and 
 | database.existingSecretUsernameKey | Username key for exising secret                           | null              |
 | database.existingSecretPasswordKey | Password key for exising secret                           | null              |
 | database.existingSecretConnectionURIKey | ConnectionURI key for exising secret                 | null              |
+| database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | [] |
+| database.googleCloudSQL.sidecarImageTag | Specific tag for the Google Cloud SQL Auth proxy sidecar image | latest  |
+| database.googleCloudSQL.resources | Google Cloud SQL Auth proxy resource requests and limits   | {}                |
 | password.complexity              | Complexity requirement for Metabase account's password      | normal            |
 | password.length                  | Minimum length required for Metabase account's password     | 6                 |
 | timeZone                         | Service time zone                                           | UTC               |

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -172,6 +172,17 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- if gt (len .Values.database.googleCloudSQL.instanceConnectionNames) 0 }}
+        - name: cloudsql-proxy
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{ or .Values.database.googleCloudSQL.sidecarImageTag "latest" }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ join "," .Values.database.googleCloudSQL.instanceConnectionNames }}"
+          securityContext:
+            runAsNonRoot: true
+          resources:
+{{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -65,7 +65,7 @@ database:
     instanceConnectionNames: []
     ## Option to use a specific version of the *Cloud SQL Auth proxy* sidecar image.
     ## ref: https://console.cloud.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy
-    #sidecarImageTag: latest
+    # sidecarImageTag: latest
     ## ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar
     resources:
       {}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -52,6 +52,23 @@ database:
   # existingSecretUsernameKey:
   # existingSecretPasswordKey:
   # existingSecretConnectionURIKey:
+  ## One or more Google Cloud SQL database instances can be made available to Metabase via the *Cloud SQL Auth proxy*.
+  ## These can be used for Metabase's internal database (by specifying `host: localhost` and the port above), or as
+  ## additional databases (configured at Admin → Databases). Workload Identity should be used for authentication, so
+  ## that when `serviceAccount.create=true`, `serviceAccount.annotations` should contain:
+  ##   iam.gke.io/gcp-service-account: your-gsa@email
+  ## Ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+  googleCloudSQL:
+    ## Found in Cloud Console "Cloud SQL Instance details" or using `gcloud sql instances describe INSTANCE_ID`
+    ## example format: $project:$region:$instance=tcp:$port
+    ## Each connection must have a unique TCP port.
+    instanceConnectionNames: []
+    ## Option to use a specific version of the *Cloud SQL Auth proxy* sidecar image.
+    ## ref: https://console.cloud.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy
+    #sidecarImageTag: latest
+    ## ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar
+    resources:
+      {}
 
 password:
   # Changing Metabase password complexity:


### PR DESCRIPTION
Add support for [Google Cloud SQL](https://cloud.google.com/sql/docs/introduction) through use of the [Cloud SQL Auth proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) running [as a sidecar](https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar).

This method supports the recommended [Workload Identity](https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#workload-identity) method of authentication. It does not support using a specific service account credentials (JSON) file.

In case specific database provider support is not desirable in this chart, an alternative approach would be to allow arbitrary additional container support in the Deployment via `values.yaml` (perhaps along with an example for how to get Cloud SQL working with that approach).