### PR TITLE
Upgrade metabase image tag

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.3.1
-appVersion: v0.41.4
+version: 1.3.2
+appVersion: v0.41.5
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                   | controller pods annotations                                 | {}                |
 | podLabels                        | extra pods labels                                           | {}                |
 | image.repository                 | controller container image repository                       | metabase/metabase |
-| image.tag                        | controller container image tag                              | v0.39.3           |
+| image.tag                        | controller container image tag                              | v0.41.5           |
 | image.command                    | controller container image command                          | []                |
 | image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
 | fullnameOverride                 | String to fully override metabase.fullname template         | null              |

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.41.4
+  tag: v0.41.5
   command: []
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Metabase 0.41.5 is available and It also includes Log4j upgrade change.