### PR TITLE
feat: add extra environment variables from secret and values.yaml

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description: The easy, open source way for everyone in your company to ask quest
   and learn from data.
 name: metabase
 version: 1.4.0
-appVersion: v0.41.5
+appVersion: v0.41.6
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.3.3
+version: 1.4.0
 appVersion: v0.41.5
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -133,4 +133,4 @@ The following table lists the configurable parameters of the Metabase chart and 
 | envFromSecret                    | Existing secret with environment variables as KV pairs      | null              |
 | extraEnv                         | Mapping of extra environment variables                      | {}                |
 
-The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.36.3/).
+The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                   | controller pods annotations                                 | {}                |
 | podLabels                        | extra pods labels                                           | {}                |
 | image.repository                 | controller container image repository                       | metabase/metabase |
-| image.tag                        | controller container image tag                              | v0.41.5           |
+| image.tag                        | controller container image tag                              | v0.41.6           |
 | image.command                    | controller container image command                          | []                |
 | image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
 | image.pullSecrets                | controller container image pull secrets                     | []                |
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | database.existingSecretUsernameKey | Username key for exising secret                           | null              |
 | database.existingSecretPasswordKey | Password key for exising secret                           | null              |
 | database.existingSecretConnectionURIKey | ConnectionURI key for exising secret                 | null              |
+| database.existingSecretEncryptionKeyKey | EncryptionKey key for exising secret                 | null              |
 | database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | [] |
 | database.googleCloudSQL.sidecarImageTag | Specific tag for the Google Cloud SQL Auth proxy sidecar image | latest  |
 | database.googleCloudSQL.resources | Google Cloud SQL Auth proxy resource requests and limits   | {}                |
@@ -129,5 +130,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | siteUrl                          | Base URL, useful for serving behind a reverse proxy         | null              |
 | session.maxSessionAge            | Session expiration defined in minutes                       | 20160             |
 | session.sessionCookies           | When browser is closed, user login session will expire      | null              |
+| envFromSecret                    | Existing secret with environment variables as KV pairs      | null              |
+| extraEnv                         | Mapping of extra environment variables                      | {}                |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](http://www.metabase.com/docs/v0.36.3/).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -78,12 +78,12 @@ spec:
           - name: MB_DB_FILE
             value: {{ .Values.database.file }}
           {{- end }}
-          {{- if .Values.database.encryptionKey }}
+          {{- if or .Values.database.existingSecretEncryptionKeyKey .Values.database.encryptionKey }}
           - name: MB_ENCRYPTION_SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "metabase.fullname" . }}-database
-                key: encryptionKey
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .))}}
+                key: {{ or .Values.database.existingSecretEncryptionKeyKey "encryptionKey" }} 
           {{- end }}
           {{- if ne (.Values.database.type | lower) "h2" }}
             {{- if or .Values.database.existingSecretConnectionURIKey .Values.database.connectionURI }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -150,6 +150,11 @@ spec:
           - name: MB_COOKIE_SAMESITE
             value: {{ .Values.session.cookieSameSite | quote }}
           {{- end }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -150,6 +150,10 @@ spec:
           - name: MB_COOKIE_SAMESITE
             value: {{ .Values.session.cookieSameSite | quote }}
           {{- end }}
+          {{- range .Values.extraEnv }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
             - secretRef:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -215,3 +215,6 @@ awsEKS:
     # sgIds:
     #   - sg-abc123
     #   - sg-xyz456
+
+#envFromSecret: your-secret-with-envs
+envFromSecret: ""

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -39,7 +39,7 @@ database:
   type: h2
   ## Specify file to store H2 database.  You will also have to back this with a volume (cf. extraVolume and extraVolumeMounts)!
   # file:
-  # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >> 
+  # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >>
   ## Only need when you use mysql / postgres
   # host:
   # port:
@@ -217,8 +217,8 @@ awsEKS:
     #   - sg-abc123
     #   - sg-xyz456
 
-#envFromSecret: your-secret-with-envs
 envFromSecret: ""
+# envFromSecret: your-secret-with-envs
 
 extraEnv: {}
 #  - name: MB_CHECK_FOR_UPDATES

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.41.5
+  tag: v0.41.6
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -218,3 +218,7 @@ awsEKS:
 
 #envFromSecret: your-secret-with-envs
 envFromSecret: ""
+
+extraEnv: {}
+#  - name: MB_CHECK_FOR_UPDATES
+#    value: false

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -39,7 +39,7 @@ database:
   type: h2
   ## Specify file to store H2 database.  You will also have to back this with a volume (cf. extraVolume and extraVolumeMounts)!
   # file:
-  # encryptionKey: << YOUR ENCRYPTION KEY >>
+  # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >> 
   ## Only need when you use mysql / postgres
   # host:
   # port:
@@ -53,6 +53,7 @@ database:
   # existingSecretUsernameKey:
   # existingSecretPasswordKey:
   # existingSecretConnectionURIKey:
+  # existingSecretEncryptionKeyKey:
   ## One or more Google Cloud SQL database instances can be made available to Metabase via the *Cloud SQL Auth proxy*.
   ## These can be used for Metabase's internal database (by specifying `host: localhost` and the port above), or as
   ## additional databases (configured at Admin → Databases). Workload Identity should be used for authentication, so


### PR DESCRIPTION
First of all, thanks for maintaining this chart @pmint93.

This aims to add some flexibility to add [environment variables](https://www.metabase.com/docs/latest/operations-guide/environment-variables.html). 

I think it's cumbersome to create values.yaml entries for every possible configuration and it's nice to add some sensible variables like `MB_GOOGLE_AUTH_CLIENT_ID` from a secret.

I also added the possibility to set the database encryption key based on a key from `existingSecret`.