### PR TITLE
quote extraEnv values

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.4.0
+version: 1.4.1
 appVersion: v0.41.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .))}}
-                key: {{ or .Values.database.existingSecretEncryptionKeyKey "encryptionKey" }} 
+                key: {{ or .Values.database.existingSecretEncryptionKeyKey "encryptionKey" }}
           {{- end }}
           {{- if ne (.Values.database.type | lower) "h2" }}
             {{- if or .Values.database.existingSecretConnectionURIKey .Values.database.connectionURI }}
@@ -152,7 +152,7 @@ spec:
           {{- end }}
           {{- range .Values.extraEnv }}
           - name: {{ .name }}
-            value: {{ .value }}
+            value: {{ .value | quote }}
           {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:


### PR DESCRIPTION
By not having the values quotes our upgrades failed and rolled back to the 1.3.3 chart.

Bug:

```
$ helm template metabase-mb-staging pmint93/metabase -n mb-staging -f values.yaml  | kubeconform --strict --kubernetes-version 1.21.0
stdin - Deployment metabase-mb-staging is invalid: For field spec.template.spec.containers.0.env.13.value: Invalid type. Expected: [string,null], given: boolean - For field spec.template.spec.containers.0.env.14.value: Invalid type. Expected: [string,null], given: integer - For field spec.template.spec.containers.0.env.15.value: Invalid type. Expected: [string,null], given: integer
```

Snippet of said `values.yaml`:

```yaml
extraEnv:
- name: MB_CHECK_FOR_UPDATES
  value: "false"
```

By quoting our test case passes `kubeconform` and `kubectl apply -f - --dry-run=client` checks.