### PR TITLE
Allow setting spec.strategy.type=Recreate

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.4.1
+version: 1.4.2
 appVersion: v0.41.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     matchLabels:
       app: {{ template "metabase.name" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -169,6 +169,11 @@ ingress:
 #
 # log4jProperties:
 
+# The deployment strategy to use
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+# strategy:
+#   type: "Recreate"
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false


### PR DESCRIPTION
When using a volume backed by block storage it is not possible to use
the same volume on different nodes at the same time:
`Multi-Attach error for volume ... Volume is already used by pod(s) ...`
(cf. e.g. https://stackoverflow.com/q/46887118)

Thus it would be nice if the Helm chart would allow me to set
`spec.strategy.type=Recreate`, to prevent multiple pods from running
at the same time (on different nodes):
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec

Closes: https://github.com/pmint93/helm-charts/issues/28
