### PR TITLE
Allow all helm features for extraEnv values

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.4.3
+version: 2.0.0
 appVersion: v0.41.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 1.4.2
+version: 1.4.3
 appVersion: v0.41.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -130,7 +130,6 @@ The following table lists the configurable parameters of the Metabase chart and 
 | siteUrl                          | Base URL, useful for serving behind a reverse proxy         | null              |
 | session.maxSessionAge            | Session expiration defined in minutes                       | 20160             |
 | session.sessionCookies           | When browser is closed, user login session will expire      | null              |
-| envFromSecret                    | Existing secret with environment variables as KV pairs      | null              |
 | extraEnv                         | Mapping of extra environment variables                      | {}                |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -154,10 +154,7 @@ spec:
           - name: MB_COOKIE_SAMESITE
             value: {{ .Values.session.cookieSameSite | quote }}
           {{- end }}
-          {{- range .Values.extraEnv }}
-          - name: {{ .name }}
-            value: {{ .value | quote }}
-          {{- end }}
+          {{- .Values.extraEnv | toYaml | nindent 10 }}
           {{- if .Values.envFromSecret }}
           envFrom:
             - secretRef:

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -155,11 +155,6 @@ spec:
             value: {{ .Values.session.cookieSameSite | quote }}
           {{- end }}
           {{- .Values.extraEnv | toYaml | nindent 10 }}
-          {{- if .Values.envFromSecret }}
-          envFrom:
-            - secretRef:
-                name: {{ .Values.envFromSecret }}
-          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -154,7 +154,9 @@ spec:
           - name: MB_COOKIE_SAMESITE
             value: {{ .Values.session.cookieSameSite | quote }}
           {{- end }}
+          {{- if gt (len .Values.extraEnv) 0 }}
           {{- .Values.extraEnv | toYaml | nindent 10 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -228,3 +228,8 @@ envFromSecret: ""
 extraEnv: {}
 #  - name: MB_CHECK_FOR_UPDATES
 #    value: false
+#  - name: MB_ADMIN_EMAIL
+#    valueFrom:
+#      configMapKeyRef:
+#        name: metabase
+#        key: email

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -222,9 +222,6 @@ awsEKS:
     #   - sg-abc123
     #   - sg-xyz456
 
-envFromSecret: ""
-# envFromSecret: your-secret-with-envs
-
 extraEnv: {}
 #  - name: MB_CHECK_FOR_UPDATES
 #    value: false


### PR DESCRIPTION
By just rendering extraEnv as yaml we can use all helm features like get the env value from configmaps and secrets