### PR TITLE
Fix Ingress version check to work with GKE patches

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.1.0
+version: 2.1.2
 appVersion: v0.42.3
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "metabase.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
This allows matching against Google Cloud patch versions such as `v1.21.10-gke.2000`, which would otherwise fall back to the deprecated version.