### PR TITLE
change liveness/readiness probes to use /api/health endpoint by default

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.1.0
+version: 2.1.1
 appVersion: v0.42.3
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -161,14 +161,14 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.service.internalPort }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.service.internalPort }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -119,11 +119,13 @@ extraVolumes: []
 #    emptyDir: {}
 
 livenessProbe:
+  path: /api/health
   initialDelaySeconds: 120
   timeoutSeconds: 30
   failureThreshold: 6
 
 readinessProbe:
+  path: /api/health
   initialDelaySeconds: 30
   timeoutSeconds: 3
   periodSeconds: 5


### PR DESCRIPTION
Increase efficiency of liveness/readiness probes by hitting the metabase `/api/health` endpoint instead of the home page.

Allow overriding the defaults.