### PR TITLE
Upgrade to v0.43.1; Change Postgres connection string;

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.1.2
-appVersion: v0.42.3
+version: 2.1.3
+appVersion: v0.43.1
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -47,7 +47,7 @@ database:
   # username:
   # password:
   ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
-  # connectionURI: postgres://user:password@host:port/database?ssl=true&sslmode=require&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+  # connectionURI: postgres://<host>:<port>/<database>?user=<username>&password=<password>&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory
   ## If a secret with the database credentials already exists, use the following values:
   # existingSecret:
   # existingSecretUsernameKey:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,7 +7,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.42.3
+  tag: v0.43.1
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
Hey, I updated the Postgres connection string according to the [metabase docs](https://www.metabase.com/docs/latest/operations-guide/configuring-application-database.html) because the current schema didn't work for me.

Also bumped up the Metabase version to v0.43.1

If there is anything else that needs changing, please let me know.