### PR TITLE
feat(config): add support for config.yaml file

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.2.1
+version: 2.2.2
 appVersion: v0.44.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/config.yaml
+++ b/charts/metabase/templates/config.yaml
@@ -13,3 +13,7 @@ data:
   log4j.properties:
 {{ toYaml .Values.log4jProperties | indent 4}}
   {{- end}}
+  config.yaml:
+    version: 1
+    config: 
+{{ toYaml .Values.config | indent 6}}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -214,13 +214,19 @@ spec:
       serviceAccountName: {{ template "metabase.serviceAccountName" . }}
       volumes:
         {{- if .Values.log4jProperties}}
-        - name: config
+        - name: log4j
           configMap:
             name: {{ template "metabase.fullname" . }}-config
             items:
             - key: log4j.properties
               path: log4j.properties
         {{- end }}
+        - name: config
+          configMap:
+            name: {{ template "metabase.fullname" . }}-config
+            items:
+            - key: config.yaml
+              path: config.yaml
         {{- if ne (len .Values.extraVolumes) 0 }}
           {{ toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -92,6 +92,28 @@ session:
   # sessionCookies:
   # cookieSameSite:
 
+# Specifies the config to use as config.yaml, as per
+# https://github.com/metabase/metabase/pull/25986/files
+#
+config:
+  # users:
+  #   - first_name: Cam
+  #     last_name: Saul
+  #     password: 2cans
+  #     email: cam@example.com
+  #   - first_name: Cam
+  #     last_name: Era
+  #     password: 2cans
+  #     email: cam.era@example.com
+  # databases:
+  #   - type: postgres
+  #     host: localhost
+  #     port: 5432
+  #     name: test-data
+  #     password: {{ env MY_POSTGRES_PASSWORD }}
+  # settings:
+  #   my-setting: 1234
+
 # specify init containers, e.g. for module download
 extraInitContainers: []
 #  - name: download-modules


### PR DESCRIPTION
Support for specifying a config.yaml config file was added
[here](https://github.com/metabase/metabase/pull/25986/files). I'm not
sure if this is the best way to add support for this, but would love to
have the ability to specify the databases as part of the Helm Chart
values.