### PR TITLE
Add possibility to configure additional labels and annotations for the deployment

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.2.1
+version: 2.3.0
 appVersion: v0.44.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -49,88 +49,90 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Metabase chart and their default values.
 
-| Parameter                        | Description                                                 | Default           |
-| -------------------------------  | ----------------------------------------------------------- | ----------------- |
-| replicaCount                     | desired number of controller pods                           | 1                 |
-| podAnnotations                   | controller pods annotations                                 | {}                |
-| podLabels                        | extra pods labels                                           | {}                |
-| image.repository                 | controller container image repository                       | metabase/metabase |
-| image.tag                        | controller container image tag                              | v0.41.6           |
-| image.command                    | controller container image command                          | []                |
-| image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
-| image.pullSecrets                | controller container image pull secrets                     | []                |
-| fullnameOverride                 | String to fully override metabase.fullname template         | null              |
-| listen.host                      | Listening on a specific network host                        | 0.0.0.0           |
-| listen.port                      | Listening on a specific network port                        | 3000              |
-| ssl.enabled                      | Enable SSL to run over HTTPS                                | false             |
-| ssl.port                         | SSL port                                                    | null              |
-| ssl.keyStore                     | The key store in JKS format                                 | null              |
-| ssl.keyStorePassword             | The password for key Store                                  | null              |
-| database.type                    | Backend database type                                       | h2                |
-| database.encryptionKey           | Secret key for encrypt sensitive information into database  | null              |
-| database.connectionURI           | Database connection URI (alternative to the below settings) | null              |
-| database.host                    | Database host                                               | null              |
-| database.port                    | Database port                                               | null              |
-| database.file                    | Database file (for H2; also add a volume to store it!)      | null              |
-| database.dbname                  | Database name                                               | null              |
-| database.username                | Database username                                           | null              |
-| database.password                | Database password                                           | null              |
-| database.existingSecret          | Exising secret for database credentials                     | null              |
-| database.existingSecretUsernameKey | Username key for exising secret                           | null              |
-| database.existingSecretPasswordKey | Password key for exising secret                           | null              |
-| database.existingSecretConnectionURIKey | ConnectionURI key for exising secret                 | null              |
-| database.existingSecretEncryptionKeyKey | EncryptionKey key for exising secret                 | null              |
-| database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | [] |
-| database.googleCloudSQL.sidecarImageTag | Specific tag for the Google Cloud SQL Auth proxy sidecar image | latest  |
-| database.googleCloudSQL.resources | Google Cloud SQL Auth proxy resource requests and limits   | {}                |
-| password.complexity              | Complexity requirement for Metabase account's password      | normal            |
-| password.length                  | Minimum length required for Metabase account's password     | 6                 |
-| timeZone                         | Service time zone                                           | UTC               |
-| emojiLogging                     | Get a funny emoji in service log                            | true              |
-| colorLogging                     | Color log lines. When set to false it will disable log line colors | true       |
-| javaOpts                         | JVM options                                                 | null              |
-| pluginsDirectory                 | A directory with Metabase plugins                           | null              |
-| extraInitContainers              | Additional init containers e.g. to download plugins         | []                |
-| extraVolumes                     | Additional server volumes                                   | []                |
-| extraVolumeMounts                | Additional server volumeMounts                              | []                |
-| livenessProbe.initialDelaySeconds | Delay before liveness probe is initiated                   | 120               |
-| livenessProbe.timeoutSeconds     | When the probe times out                                    | 30                |
-| livenessProbe.failureThreshold   | Minimum consecutive failures for the probe                  | 6                 |
-| readinessProbe.initialDelaySeconds | Delay before readiness probe is initiated                 | 30                |
-| readinessProbe.timeoutSeconds    | When the probe times out                                    | 3                 |
-| readinessProbe.periodSeconds     | How often to perform the probe                              | 5                 |
-| service.type                     | ClusterIP, NodePort, or LoadBalancer                        | ClusterIP         |
-| service.loadBalancerSourceRanges | Array of Source Ranges                                      | null              |
-| service.externalPort             | Service external port                                       | 80                |
-| service.internalPort             | Service internal port, should be the same as `listen.port`  | 3000              |
-| service.nodePort                 | Service node port                                           | null              |
-| service.annotations              | Service annotations                                         | {}                |
-| serviceAccount.create            | Specifies whether a service account should be created       | false             |
-| serviceAccount.annotations       | Annotations to add to the service account                   | {}                |
-| serviceAccount.name              | The name of the service account to use                      | null              |
-| awsEKS.sgp.enabled               | Enable EKS's Security Groups Policy                         | false             |
-| awsEKS.sgp.sgIds                 | List of AWS Security Group IDs to attach to the pod         | null              |
-| ingress.enabled                  | Enable ingress controller resource                          | false             |
-| ingress.className                | Ingress class name (Kubernetes 1.18+)                       | null              |
-| ingress.hosts                    | Ingress resource hostnames                                  | ["*"]             |
-| ingress.path                     | Ingress path                                                | /                 |
-| ingress.pathType                 | Ingress pathType                                            | Prefix            |
-| ingress.labels                   | Ingress labels configuration                                | null              |
-| ingress.annotations              | Ingress annotations configuration                           | {}                |
-| ingress.tls                      | Ingress TLS configuration                                   | null              |
-| log4jProperties                  | Custom `log4j.properties` file                              | null              |
-| resources                        | Server resource requests and limits                         | {}                |
-| nodeSelector                     | Node labels for pod assignment                              | {}                |
-| tolerations                      | Toleration labels for pod assignment                        | []                |
-| affinity                         | Affinity settings for pod assignment                        | {}                |
-| priorityClass                    | PriorityClass settings for pod assignment                   | null              |
-| jetty.maxThreads                 | Jetty max number of threads                                 | null              |
-| jetty.minThreads                 | Jetty min number of threads                                 | null              |
-| jetty.maxQueued                  | Jetty max queue size                                        | null              |
-| jetty.maxIdleTime                | Jetty max idle time                                         | null              |
-| siteUrl                          | Base URL, useful for serving behind a reverse proxy         | null              |
-| session.maxSessionAge            | Session expiration defined in minutes                       | 20160             |
-| session.sessionCookies           | When browser is closed, user login session will expire      | null              |
-| extraEnv                         | Mapping of extra environment variables                      | {}                |
+| Parameter                                       | Description                                                                | Default           |
+|-------------------------------------------------|----------------------------------------------------------------------------|-------------------|
+| replicaCount                                    | desired number of controller pods                                          | 1                 |
+| deploymentAnnotations                           | extra deployment annotations                                               | {}                |
+| deploymentLabels                                | extra deployment labels                                                    | {}                |
+| podAnnotations                                  | controller pods annotations                                                | {}                |
+| podLabels                                       | extra pods labels                                                          | {}                |
+| image.repository                                | controller container image repository                                      | metabase/metabase |
+| image.tag                                       | controller container image tag                                             | v0.41.6           |
+| image.command                                   | controller container image command                                         | []                |
+| image.pullPolicy                                | controller container image pull policy                                     | IfNotPresent      |
+| image.pullSecrets                               | controller container image pull secrets                                    | []                |
+| fullnameOverride                                | String to fully override metabase.fullname template                        | null              |
+| listen.host                                     | Listening on a specific network host                                       | 0.0.0.0           |
+| listen.port                                     | Listening on a specific network port                                       | 3000              |
+| ssl.enabled                                     | Enable SSL to run over HTTPS                                               | false             |
+| ssl.port                                        | SSL port                                                                   | null              |
+| ssl.keyStore                                    | The key store in JKS format                                                | null              |
+| ssl.keyStorePassword                            | The password for key Store                                                 | null              |
+| database.type                                   | Backend database type                                                      | h2                |
+| database.encryptionKey                          | Secret key for encrypt sensitive information into database                 | null              |
+| database.connectionURI                          | Database connection URI (alternative to the below settings)                | null              |
+| database.host                                   | Database host                                                              | null              |
+| database.port                                   | Database port                                                              | null              |
+| database.file                                   | Database file (for H2; also add a volume to store it!)                     | null              |
+| database.dbname                                 | Database name                                                              | null              |
+| database.username                               | Database username                                                          | null              |
+| database.password                               | Database password                                                          | null              |
+| database.existingSecret                         | Exising secret for database credentials                                    | null              |
+| database.existingSecretUsernameKey              | Username key for exising secret                                            | null              |
+| database.existingSecretPasswordKey              | Password key for exising secret                                            | null              |
+| database.existingSecretConnectionURIKey         | ConnectionURI key for exising secret                                       | null              |
+| database.existingSecretEncryptionKeyKey         | EncryptionKey key for exising secret                                       | null              |
+| database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | []                |
+| database.googleCloudSQL.sidecarImageTag         | Specific tag for the Google Cloud SQL Auth proxy sidecar image             | latest            |
+| database.googleCloudSQL.resources               | Google Cloud SQL Auth proxy resource requests and limits                   | {}                |
+| password.complexity                             | Complexity requirement for Metabase account's password                     | normal            |
+| password.length                                 | Minimum length required for Metabase account's password                    | 6                 |
+| timeZone                                        | Service time zone                                                          | UTC               |
+| emojiLogging                                    | Get a funny emoji in service log                                           | true              |
+| colorLogging                                    | Color log lines. When set to false it will disable log line colors         | true              |
+| javaOpts                                        | JVM options                                                                | null              |
+| pluginsDirectory                                | A directory with Metabase plugins                                          | null              |
+| extraInitContainers                             | Additional init containers e.g. to download plugins                        | []                |
+| extraVolumes                                    | Additional server volumes                                                  | []                |
+| extraVolumeMounts                               | Additional server volumeMounts                                             | []                |
+| livenessProbe.initialDelaySeconds               | Delay before liveness probe is initiated                                   | 120               |
+| livenessProbe.timeoutSeconds                    | When the probe times out                                                   | 30                |
+| livenessProbe.failureThreshold                  | Minimum consecutive failures for the probe                                 | 6                 |
+| readinessProbe.initialDelaySeconds              | Delay before readiness probe is initiated                                  | 30                |
+| readinessProbe.timeoutSeconds                   | When the probe times out                                                   | 3                 |
+| readinessProbe.periodSeconds                    | How often to perform the probe                                             | 5                 |
+| service.type                                    | ClusterIP, NodePort, or LoadBalancer                                       | ClusterIP         |
+| service.loadBalancerSourceRanges                | Array of Source Ranges                                                     | null              |
+| service.externalPort                            | Service external port                                                      | 80                |
+| service.internalPort                            | Service internal port, should be the same as `listen.port`                 | 3000              |
+| service.nodePort                                | Service node port                                                          | null              |
+| service.annotations                             | Service annotations                                                        | {}                |
+| serviceAccount.create                           | Specifies whether a service account should be created                      | false             |
+| serviceAccount.annotations                      | Annotations to add to the service account                                  | {}                |
+| serviceAccount.name                             | The name of the service account to use                                     | null              |
+| awsEKS.sgp.enabled                              | Enable EKS's Security Groups Policy                                        | false             |
+| awsEKS.sgp.sgIds                                | List of AWS Security Group IDs to attach to the pod                        | null              |
+| ingress.enabled                                 | Enable ingress controller resource                                         | false             |
+| ingress.className                               | Ingress class name (Kubernetes 1.18+)                                      | null              |
+| ingress.hosts                                   | Ingress resource hostnames                                                 | ["*"]             |
+| ingress.path                                    | Ingress path                                                               | /                 |
+| ingress.pathType                                | Ingress pathType                                                           | Prefix            |
+| ingress.labels                                  | Ingress labels configuration                                               | null              |
+| ingress.annotations                             | Ingress annotations configuration                                          | {}                |
+| ingress.tls                                     | Ingress TLS configuration                                                  | null              |
+| log4jProperties                                 | Custom `log4j.properties` file                                             | null              |
+| resources                                       | Server resource requests and limits                                        | {}                |
+| nodeSelector                                    | Node labels for pod assignment                                             | {}                |
+| tolerations                                     | Toleration labels for pod assignment                                       | []                |
+| affinity                                        | Affinity settings for pod assignment                                       | {}                |
+| priorityClass                                   | PriorityClass settings for pod assignment                                  | null              |
+| jetty.maxThreads                                | Jetty max number of threads                                                | null              |
+| jetty.minThreads                                | Jetty min number of threads                                                | null              |
+| jetty.maxQueued                                 | Jetty max queue size                                                       | null              |
+| jetty.maxIdleTime                               | Jetty max idle time                                                        | null              |
+| siteUrl                                         | Base URL, useful for serving behind a reverse proxy                        | null              |
+| session.maxSessionAge                           | Session expiration defined in minutes                                      | 20160             |
+| session.sessionCookies                          | When browser is closed, user login session will expire                     | null              |
+| extraEnv                                        | Mapping of extra environment variables                                     | {}                |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | trim | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -3,6 +3,8 @@
 # https://github.com/metabase/metabase/issues/2754
 # NOTE: Should remain 1
 replicaCount: 1
+deploymentAnnotations: {}
+deploymentLabels: {}
 podAnnotations: {}
 podLabels: {}
 image:


### PR DESCRIPTION
For many kubernetes tools we need to set additional annotations and labels on the deployment entity. 

This PR introduces new values to configure custom annotations and labels, similar to what we already have on pod level.