### PR TITLE
Enable IAM Authentication for CloudSQL Proxy

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.3.0
+version: 2.3.1
 appVersion: v0.44.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -198,8 +198,36 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ join "," .Values.database.googleCloudSQL.instanceConnectionNames }}"
+            - "-term_timeout=10s"
+            - "-structured_logs"
+            - "-use_http_health_check"
+            - "-enable_iam_login"
           securityContext:
             runAsNonRoot: true
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 2
+          startupProbe:
+            httpGet:
+              path: /startup
+              port: 8090
+            periodSeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 20
           resources:
 {{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
         {{- end }}


### PR DESCRIPTION
This PR sets the `enable_iam_login` flag on CloudSQL Proxy, to enable [automatic IAM database authentication](https://cloud.google.com/sql/docs/postgres/iam-logins#logging_in_with_automatic). Since this just adds IAM capability, I didn't see any risks to need to wrap this addition in a conditional. 

I've also added a few best practice too, CloudSQL Proxy health checks, and log improvements. 