### PR TITLE
Bump Metabase to v0.45.1

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.3.0
-appVersion: v0.44.6
+version: 2.4.0
+appVersion: v0.45.1
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -9,7 +9,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.44.6
+  tag: v0.45.1
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
### What

Bump Metabase version to 0.45.1

### Why

[Metabase 0.45.x](https://www.metabase.com/releases/Metabase-0.45) has some new features that look interesting.