### PR TITLE
Bump Metabase version to v0.45.3

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.6.2
-appVersion: v0.45.2
+version: 2.6.3
+appVersion: v0.45.3
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -9,7 +9,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.45.1
+  tag: v0.45.3
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
This PR bumps the Metabase Docker image to v0.45.3