### PR TITLE
Add PodDisruptionBudget policy

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.7.1
+version: 2.7.2
 appVersion: v0.46.4
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -52,6 +52,9 @@ The following table lists the configurable parameters of the Metabase chart and 
 | Parameter                                       | Description                                                                | Default           |
 |-------------------------------------------------|----------------------------------------------------------------------------|-------------------|
 | replicaCount                                    | desired number of controller pods                                          | 1                 |
+| pdb.create                                      | Enable/disable a Pod Disruption Budget creation                            | false             |
+| pdb.minAvailable                                | Minimum number/percentage of pods that should remain scheduled             | 1                 |
+| pdb.maxUnavailable                              | Maximum number/percentage of pods that may be made unavailable             |                   |
 | deploymentAnnotations                           | extra deployment annotations                                               | {}                |
 | deploymentLabels                                | extra deployment labels                                                    | {}                |
 | podAnnotations                                  | controller pods annotations                                                | {}                |

--- a/charts/metabase/templates/pdb.yaml
+++ b/charts/metabase/templates/pdb.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      {{- if .Values.deploymentLabels }}
+{{- toYaml .Values.deploymentLabels | trim | indent 6 }}
+      {{- end }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -3,6 +3,12 @@
 # https://github.com/metabase/metabase/issues/2754
 # NOTE: Should remain 1
 replicaCount: 1
+
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+
 deploymentAnnotations: {}
 deploymentLabels: {}
 podAnnotations: {}


### PR DESCRIPTION
In order to prevent downtime during cluster scaling operation, add possibility to create a PodDisruptionBudget policy.