### PR TITLE
chore(charts/metabase/Chart): bump chart version to v0.46.6.1

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.7.3
-appVersion: v0.46.4
+version: 2.7.4
+appVersion: v0.46.6.1
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                                  | controller pods annotations                                                | {}                |
 | podLabels                                       | extra pods labels                                                          | {}                |
 | image.repository                                | controller container image repository                                      | metabase/metabase |
-| image.tag                                       | controller container image tag                                             | v0.46.4           |
+| image.tag                                       | controller container image tag                                             | v0.46.6.1         |
 | image.command                                   | controller container image command                                         | []                |
 | image.pullPolicy                                | controller container image pull policy                                     | IfNotPresent      |
 | image.pullSecrets                               | controller container image pull secrets                                    | []                |

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -15,7 +15,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.46.4
+  tag: v0.46.6.1
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
[From Metabase Release v0.46.6.1](https://github.com/metabase/metabase/releases/tag/v0.46.6.1)

> Upgrade your Metabase installation IMMEDIATELY.

I'm not super familiar with Helm, but saw from the previous commit history that I think this is how to update to the latest image.