### PR TITLE
Update metabase version to v0.46.6.2

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.7.4
-appVersion: v0.46.6.1
+version: 2.7.5
+appVersion: v0.46.6.2
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                                  | controller pods annotations                                                | {}                |
 | podLabels                                       | extra pods labels                                                          | {}                |
 | image.repository                                | controller container image repository                                      | metabase/metabase |
-| image.tag                                       | controller container image tag                                             | v0.46.6.1         |
+| image.tag                                       | controller container image tag                                             | v0.46.6.2         |
 | image.command                                   | controller container image command                                         | []                |
 | image.pullPolicy                                | controller container image pull policy                                     | IfNotPresent      |
 | image.pullSecrets                               | controller container image pull secrets                                    | []                |

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -15,7 +15,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.46.6.1
+  tag: v0.46.6.2
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
Metabase's security release 0.46.6.1 had a bug that prevents Google's sign in. [Version 0.46.6.2](https://github.com/metabase/metabase/releases/tag/v0.46.6.2) fixes this issue.