### PR TITLE
feat(secret): support env from secret

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.7.6
+version: 2.7.7
 appVersion: v0.46.6.4
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -146,5 +146,6 @@ The following table lists the configurable parameters of the Metabase chart and 
 | session.maxSessionAge                           | Session expiration defined in minutes                                      | 20160             |
 | session.sessionCookies                          | When browser is closed, user login session will expire                     | null              |
 | extraEnv                                        | Mapping of extra environment variables                                     | {}                |
+| envFrom                                         | Mapping of extra environment variables from secret and/or configMap        | []                |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -176,6 +176,13 @@ spec:
           {{- if gt (len .Values.extraEnv) 0 }}
           {{- .Values.extraEnv | toYaml | nindent 10 }}
           {{- end }}
+          {{- if gt (len .Values.envFrom) 0 }}
+          envFrom:
+            {{- range .Values.envFrom }}
+            - {{ .type }}Ref:
+                name: {{ .name }}
+            {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
             {{- if .Values.monitoring.enabled }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -270,3 +270,9 @@ extraEnv: {}
 #      configMapKeyRef:
 #        name: metabase
 #        key: email
+
+envFrom: []
+  # - type: secret
+  #   name: metabase-secret
+  # - type: configMap
+  #   name: metabase-cm


### PR DESCRIPTION
getting an env from secret is useful when we want to add another ENV without adding additional ENV on the deployment manifest. yet we can also use  [externalsecret](https://external-secrets.io/latest/) to generate the secret from another [secret provider](https://external-secrets.io/latest/provider/aws-secrets-manager/) 