### PR TITLE
charts/metabase add securityContext hooks

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.10.0
+version: 2.10.1
 appVersion: v0.47.2
 maintainers:
   - name: pmint93

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.10.1
+version: 2.10.2
 appVersion: v0.47.2
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -90,6 +90,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | []                |
 | database.googleCloudSQL.sidecarImageTag         | Specific tag for the Google Cloud SQL Auth proxy sidecar image             | latest            |
 | database.googleCloudSQL.resources               | Google Cloud SQL Auth proxy resource requests and limits                   | {}                |
+| database.googleCloudSQL.securityContext         | Google Cloud SQL Security Context                                          | runAsNonRoot: true| 
 | password.complexity                             | Complexity requirement for Metabase account's password                     | normal            |
 | password.length                                 | Minimum length required for Metabase account's password                    | 6                 |
 | timeZone                                        | Service time zone                                                          | UTC               |
@@ -148,5 +149,6 @@ The following table lists the configurable parameters of the Metabase chart and 
 | extraEnv                                        | Mapping of extra environment variables                                     | {}                |
 | envFrom                                         | Mapping of extra environment variables from secret and/or configMap        | []                |
 | sidecars                                        | Mapping of container sidecars for the main deployment                      | []                |
+| securityContext                                 | Security Context for the Metabase pod                                      | {}                | 
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -213,6 +213,10 @@ spec:
             - containerPort: {{ .Values.monitoring.port }}
               name: metrics
             {{- end }}
+          {{- if .Values.metabaseSecurityContext}}
+          securityContext: 
+          {{- .Values.metabaseSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
@@ -250,7 +254,7 @@ spec:
             - "-use_http_health_check"
             - "-enable_iam_login"
           securityContext:
-            runAsNonRoot: true
+          {{- .Values.cloudsqlSecurityContext | toYaml | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /liveness

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -213,9 +213,9 @@ spec:
             - containerPort: {{ .Values.monitoring.port }}
               name: metrics
             {{- end }}
-          {{- if .Values.metabaseSecurityContext}}
+          {{- if .Values.securityContext}}
           securityContext: 
-          {{- .Values.metabaseSecurityContext | toYaml | nindent 12 }}
+          {{- .Values.securityContext | toYaml | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -254,7 +254,7 @@ spec:
             - "-use_http_health_check"
             - "-enable_iam_login"
           securityContext:
-          {{- .Values.cloudsqlSecurityContext | toYaml | nindent 12 }}
+          {{- .Values.database.googleCloudSQL.securityContext | toYaml | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /liveness

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -81,6 +81,8 @@ database:
     # sidecarImageTag: latest
     ## ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar
     resources: {}
+    securityContext:
+      runAsNonRoot: true
 
 password:
   # Changing Metabase password complexity:
@@ -279,11 +281,8 @@ envFrom: []
   # - type: configMap
   #   name: metabase-cm
 
-metabaseSecurityContext: {}
+securityContext: {}
   
-cloudsqlSecurityContext:
-  runAsNonRoot: true
-
 sidecars: []
   # - name: busybox
   #   image: busybox

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -278,3 +278,8 @@ envFrom: []
   #   name: metabase-secret
   # - type: configMap
   #   name: metabase-cm
+
+metabaseSecurityContext: {}
+  
+cloudsqlSecurityContext:
+  runAsNonRoot: true

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -282,7 +282,7 @@ envFrom: []
   #   name: metabase-cm
 
 securityContext: {}
-  
+
 sidecars: []
   # - name: busybox
   #   image: busybox


### PR DESCRIPTION
This will allow users to specify their own securityContext.

I created separate hooks for metabase and cloudsql so that they can be different if the user wants them to be. Let me know if you like these changes and I can add them to the documentation as a part of this PR. 
