### PR TITLE
charts/metabase add sidecars for main deployment

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.10.0
+version: 2.10.1
 appVersion: v0.47.2
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -50,7 +50,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the Metabase chart and their default values.
 
 | Parameter                                       | Description                                                                | Default           |
-| ----------------------------------------------- | -------------------------------------------------------------------------- | ----------------- |
+|-------------------------------------------------|----------------------------------------------------------------------------|-------------------|
 | replicaCount                                    | desired number of controller pods                                          | 1                 |
 | pdb.create                                      | Enable/disable a Pod Disruption Budget creation                            | false             |
 | pdb.minAvailable                                | Minimum number/percentage of pods that should remain scheduled             | 1                 |
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | podAnnotations                                  | controller pods annotations                                                | {}                |
 | podLabels                                       | extra pods labels                                                          | {}                |
 | image.repository                                | controller container image repository                                      | metabase/metabase |
-| image.tag                                       | controller container image tag                                             | v0.47.2         |
+| image.tag                                       | controller container image tag                                             | v0.47.2           |
 | image.command                                   | controller container image command                                         | []                |
 | image.pullPolicy                                | controller container image pull policy                                     | IfNotPresent      |
 | image.pullSecrets                               | controller container image pull secrets                                    | []                |
@@ -147,5 +147,6 @@ The following table lists the configurable parameters of the Metabase chart and 
 | session.sessionCookies                          | When browser is closed, user login session will expire                     | null              |
 | extraEnv                                        | Mapping of extra environment variables                                     | {}                |
 | envFrom                                         | Mapping of extra environment variables from secret and/or configMap        | []                |
+| sidecars                                        | Mapping of container sidecars for the main deployment                      | []                |
 
 The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -278,7 +278,9 @@ spec:
           resources:
 {{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
         {{- end }}
+        {{- if .Values.sidecars }}
         {{ toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -278,6 +278,7 @@ spec:
           resources:
 {{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
         {{- end }}
+        {{ toYaml .Values.sidecars | nindent 8 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -278,3 +278,19 @@ envFrom: []
   #   name: metabase-secret
   # - type: configMap
   #   name: metabase-cm
+
+sidecars: []
+  # - name: busybox
+  #   image: busybox
+  #   ports:
+  #     - containerPort: 80
+  #       name: http
+  #   resources:
+  #     requests:
+  #       memory: 100Mi
+  #       cpu: 10m
+  #     limits:
+  #       memory: 100Mi
+  #       cpu: 10m
+  #   command: ["/bin/sh"]
+  #   args: ["-c", "while true; do echo hello; sleep 10;done"]


### PR DESCRIPTION
This addition allows to add the sidecars block to the main deployment, it allows bare customization so users can custom the sidecars based on Kubernetes manifest syntax

The Chart version has already been added as well as the documentation for variables