### PR TITLE
[charts/metabase] fix: add missing port.targetPort in OpenShift Route

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.10.3
+version: 2.10.4
 appVersion: v0.47.2
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/route.yaml
+++ b/charts/metabase/templates/route.yaml
@@ -47,4 +47,6 @@ spec:
   to:
     kind: Service
     name: {{ $serviceName }}
+  port:
+    targetPort: {{ .Values.service.name }}
 {{- end }}


### PR DESCRIPTION
Currently the OpenShift route misses `port.targetPort` to point to the `metabase` port (and not `metrics`) of the service.
