### PR TITLE
[charts/metabase] : Fixing servicemonitor according to prometheus and k8s spec

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.10.4
+version: 2.10.5
 appVersion: v0.47.2
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/servicemonitor.yaml
+++ b/charts/metabase/templates/servicemonitor.yaml
@@ -11,8 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "metabase.name" . }}
-    release: {{ .Release.Name }}
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      release: {{ .Release.Name }}
   endpoints:
     - path: /metrics
       port: metrics


### PR DESCRIPTION
Hello !

I'm trying to install the metabase chart but I run into this error when enabling the `serviceMonitor` as below :

```yaml
metabase:
  monitoring:
    enabled: true
    serviceMonitor:
      enabled: true
    port: 9191
```
>Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(ServiceMonitor.spec.selector): unknown field "app" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "release" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector]

As per official [kubernetes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta) and [prometheus](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) spec, the `matchLabels` field is missing. This PR provides a fix. 

I've tested the code and it works like a charm ! :)