### PR TITLE
feat(pgbouncer): add support for service account  & sidecars in the pod 

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pgbouncer
-version: "0.2.0"
+version: "0.3.0"
 description: A Helm chart for Pgbouncer
 type: application
 home: https://github.com/pmint93/helm-charts

--- a/charts/pgbouncer/README.md
+++ b/charts/pgbouncer/README.md
@@ -70,5 +70,10 @@ The following table lists the configurable parameters of the chart and their def
 | nodeSelector                              | object    | `{}`                                                              | Node labels for pod assignment                                                                        |
 | tolerations                               | list      | `[]`                                                              | Toleration labels for pod assignment                                                                  |
 | affinity                                  | object    | `{}`                                                              | Affinity settings for pod assignment                                                                  |
+| serviceAccount                            | object    | `{enable: false}`                                                 | Service account's definition                                                                          |
+| serviceAccount.enable                     | bool      | `false`                                                           | Service account's section flag                                                                        |
+| serviceAccount.name                       | string    | `""`                                                              | Service account's name                                                                                |
+| serviceAccount.annotations                | object    | `{}`                                                              | Service account's annotations                                                                         |
+| sidecars                                  | list      | `[]`                                                              | Sidecars raw definition                                                                               |
 
 To better understand PgBouncer configuration, please refer to [this document](https://www.pgbouncer.org/config.html)

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
             - name: config
               readOnly: true
               mountPath: /etc/pgbouncer/
+        {{- range .Values.sidecars }}
+        - {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -76,3 +76,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.enable }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}

--- a/charts/pgbouncer/templates/serviceAccount.yaml
+++ b/charts/pgbouncer/templates/serviceAccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -87,3 +87,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceAccount:
+  enable: false
+  # name: saName
+  # annotations:
+  #   iam.gke.io/gcp-service-account: sa-name@project.iam.gserviceaccount.com

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -93,3 +93,11 @@ serviceAccount:
   # name: saName
   # annotations:
   #   iam.gke.io/gcp-service-account: sa-name@project.iam.gserviceaccount.com
+
+sidecars: []
+#  - name: mySidecar
+#    image: repo/image:tag
+#    imagePullPolicy: IfNotPresent
+#    args:
+#      - --foo
+#      - --bar


### PR DESCRIPTION
This contrib allows to spin out a sidecar in the pod (e.g. [gcloudsqlproxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) to provide an extra layer of security/ease between our apps and PG instances) this feature require a service-account to be mounted in the workload.

Thanks !