### PR TITLE
feat(pgbouncer): ability to disable service-account creation if alrea…

### DIFF
--- a/charts/pgbouncer/Chart.yaml
+++ b/charts/pgbouncer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pgbouncer
-version: "0.3.0"
+version: "0.4.0"
 description: A Helm chart for Pgbouncer
 type: application
 home: https://github.com/pmint93/helm-charts

--- a/charts/pgbouncer/README.md
+++ b/charts/pgbouncer/README.md
@@ -72,8 +72,9 @@ The following table lists the configurable parameters of the chart and their def
 | affinity                                  | object    | `{}`                                                              | Affinity settings for pod assignment                                                                  |
 | serviceAccount                            | object    | `{enable: false}`                                                 | Service account's definition                                                                          |
 | serviceAccount.enable                     | bool      | `false`                                                           | Service account's section flag                                                                        |
-| serviceAccount.name                       | string    | `""`                                                              | Service account's name                                                                                |
+| serviceAccount.name                       | string    | `"pgbouncer"`                                                     | Service account's name                                                                                |
 | serviceAccount.annotations                | object    | `{}`                                                              | Service account's annotations                                                                         |
 | sidecars                                  | list      | `[]`                                                              | Sidecars raw definition                                                                               |
+| serviceAccount.existingServiceAccountName | string    | `""`                                                              | Do not create a KSA but use an existing one                                                           |
 
 To better understand PgBouncer configuration, please refer to [this document](https://www.pgbouncer.org/config.html)

--- a/charts/pgbouncer/templates/deployment.yaml
+++ b/charts/pgbouncer/templates/deployment.yaml
@@ -80,5 +80,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.enable }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.existingServiceAccountName | default .Values.serviceAccount.name }}
       {{- end }}

--- a/charts/pgbouncer/templates/serviceAccount.yaml
+++ b/charts/pgbouncer/templates/serviceAccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enable }}
+{{- if and (not .Values.serviceAccount.existingServiceAccountName) .Values.serviceAccount.enable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -90,7 +90,8 @@ affinity: {}
 
 serviceAccount:
   enable: false
-  # name: saName
+  name: pgbouncer
+  # existingServiceAccountName: ""
   # annotations:
   #   iam.gke.io/gcp-service-account: sa-name@project.iam.gserviceaccount.com
 


### PR DESCRIPTION
This PR allows usage of the service-account features without creating it from this chart (i.e. avoid duplicate declaration, when the SA is already present in the namespace)

Thonks,