### PR TITLE
Add topologySpreadConstraints to metabase chart

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.11.0
+version: 2.12.0
 appVersion: v0.48.3
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -214,7 +214,7 @@ spec:
               name: metrics
             {{- end }}
           {{- if .Values.securityContext}}
-          securityContext: 
+          securityContext:
           {{- .Values.securityContext | toYaml | nindent 12 }}
           {{- end }}
           livenessProbe:
@@ -295,6 +295,10 @@ spec:
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
 {{ toYaml . | indent 8 }}
     {{- end }}
       {{- if .Values.priorityClass}}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -250,6 +250,10 @@ tolerations: []
 ##
 affinity: {}
 
+## Spread Constraints for pod assignment
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+
 ## PriorityClass for pod assignment
 ## ref:
 ## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority


### PR DESCRIPTION
This adds the possibility to add topologySpreadConstraints to the metabase chart.

example usage in values.yaml:

```yaml
topologySpreadConstraints:
  - labelSelector:
      matchLabels:
        app.kubernetes.io/name: xxx
    topologyKey: topology.kubernetes.io/zone
    maxSkew: 1
    whenUnsatisfiable: ScheduleAnyway
```