### PR TITLE
Add support for HPA

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.15.3
+version: 2.15.4
 appVersion: v0.49.11
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -19,7 +19,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "metabase.name" . }}
+  {{ if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{ end }}
   {{- with .Values.strategy }}
   strategy:
 {{ toYaml . | trim | indent 4 }}

--- a/charts/metabase/templates/hpa.yaml
+++ b/charts/metabase/templates/hpa.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "metabase.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "metabase.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  {{- with .Values.hpa.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.hpa.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -1,5 +1,12 @@
 replicaCount: 1
 
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
 pdb:
   create: false
   minAvailable: 1


### PR DESCRIPTION
Add support for scaling the Metabase pods with HPA, 
disabled by default and utilizing the `replicaCount` setting