### PR TITLE
[charts/metabase] Upgrade metabase version to 0.50.4

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.15.8
-appVersion: v0.49.13
+version: 2.16.4
+appVersion: v0.50.4
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
Official metabase just released v0.50.4 4 hours ago

https://github.com/metabase/metabase/releases/tag/v0.50.4