### PR TITLE
add support for host aliases

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.16.4
+version: 2.16.5
 appVersion: v0.50.4
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -303,6 +303,10 @@ spec:
       topologySpreadConstraints:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       {{- if .Values.priorityClass}}
       priorityClassName: {{ .Values.priorityClass }}
       {{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -7,6 +7,13 @@ hpa:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
+# Adding host aliases to the metabase deployment
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+#   - "bar.local"
+
 pdb:
   create: false
   minAvailable: 1


### PR DESCRIPTION
Hi @pmint93 I love this metabase helm chart!
Regarding the PR, I forked the repository, created a PR on my fork, merged it, and then opened a PR from master to master.
I wanted to add support for host aliases since I am working in an environment that doesn't have DNS resolving to a postgres instance and this PR should help me reach to that postgres instance using the host aliases. I believe that it will also help other users who will encounter the same scenario as I am facing.