### PR TITLE
[charts/metabase] Upgrade metabase version to 0.50.6

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.16.5
-appVersion: v0.50.4
+version: 2.16.6
+appVersion: v0.50.6
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
Metabase just release new version 0.50.6

```
Enhancements

    Disable SQL analysis by default (https://github.com/metabase/metabase/pull/44346)

Bug fixes

    If you don't have access to the root collection but inner collections, you get permission errors in QuestionPicker (https://github.com/metabase/metabase/issues/44316)
    Goal lines displayed incorrectly when axis scale is not linear (https://github.com/metabase/metabase/issues/44278)
    Field values remapping with mixed PK and a FK targeting the same PK is broken in public dashboards (https://github.com/metabase/metabase/issues/44231)
    StreamingResponse cannot be cast to class clojure.lang.Associative (https://github.com/metabase/metabase/issues/44160)
    Error while exporting a pivot table without columns in v50.x (https://github.com/metabase/metabase/issues/44159)
    Bar chart per week not showing proper information on Timeline (https://github.com/metabase/metabase/issues/23336)

Under the hood

    Rework measure search performance events (https://github.com/metabase/metabase/issues/44300)
    Remove frontend code that checks enable-query-caching (https://github.com/metabase/metabase/issues/44250)
```