### PR TITLE
[charts/metabase]Allow additional ingress paths to be configured for the ingress

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.16.6
+version: 2.16.7
 appVersion: v0.50.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -30,6 +30,9 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
+          {{- with $.Values.ingress.extraPaths }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           - path: {{ $ingressPath }}
             pathType: {{ $ingressPathType }}
             backend:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -187,6 +187,15 @@ ingress:
   # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
   path: /
   pathType: Prefix
+  # Additional ingress paths
+  extraPaths: []
+    # - path: /*
+    #   pathType: Prefix
+    #   backend:
+    #     service:
+    #       name: ssl-redirect
+    #       port:
+    #         name: use-annotation
   labels:
     # Used to add custom labels to the Ingress
     # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses


### PR DESCRIPTION
Allow additional ingress paths to be configured for the ingress by utilising a `extraPaths` config  e.g when one needs to set up a path for ssl-redirect