### PR TITLE
[charts/metabase] (feat) Allow more DB Params from existing secrets

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.16.6
+version: 2.16.7
 appVersion: v0.50.6
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -122,12 +122,36 @@ spec:
                 name: {{ (printf "%s-database" (include "metabase.fullname" .)) }}
                 key: connectionURI
             {{- else }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretHostKey }}
+          - name: MB_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretHostKey }}
+            {{- else }}
           - name: MB_DB_HOST
             value: {{ .Values.database.host | quote }}
+            {{- end }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretPortKey }}
+          - name: MB_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretPortKey }}
+            {{- else }}
           - name: MB_DB_PORT
             value: {{ .Values.database.port | quote }}
+            {{- end}}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretDatabaseNameKey }}
+          - name: MB_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretDatabaseNameKey }}
+            {{- else }}
           - name: MB_DB_DBNAME
             value: {{ .Values.database.dbname | quote }}
+            {{- end }}
             {{- end }}
             {{- if and .Values.database.existingSecret .Values.database.existingSecretUsernameKey }}
           - name: MB_DB_USER

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             value: {{ .Values.database.port | quote }}
             {{- end}}
             {{- if and .Values.database.existingSecret .Values.database.existingSecretDatabaseNameKey }}
-          - name: MB_DB_HOST
+          - name: MB_DB_DBNAME
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.database.existingSecret }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -80,6 +80,9 @@ database:
   # existingSecretPasswordKey:
   # existingSecretConnectionURIKey:
   # existingSecretEncryptionKeyKey:
+  # existingSecretPortKey:
+  # existingSecretHostKey:
+  # existingSecretDatabaseNameKey:
   ## One or more Google Cloud SQL database instances can be made available to Metabase via the *Cloud SQL Auth proxy*.
   ## These can be used for Metabase's internal database (by specifying `host: localhost` and the port above), or as
   ## additional databases (configured at Admin → Databases). Workload Identity should be used for authentication, so


### PR DESCRIPTION
Allows setting of `DB_HOST`, `DB_PORT` and `DB_DBNAME` from an existing secret. 

I am not 100% sure this is the best way to do it, and I believe it might be better to do a refactor of the `existingSecret` like so:
```yml
existingSecret:
  name:
  usernameKey:
  passwordKey:
  hostKey:
  portKey:
  databaseNameKey:
  encryptionKeyKey:
  connetionUriKey:
```

But, this would've been a breaking change. 