### PR TITLE
[charts/metabase] fix label indentation in pdb

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.17.1
+version: 2.17.2
 appVersion: v0.51.1
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/pdb.yaml
+++ b/charts/metabase/templates/pdb.yaml
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       app: {{ template "metabase.name" . }}
       {{- if .Values.deploymentLabels }}
-{{- toYaml .Values.deploymentLabels | trim | indent 6 }}
+{{ toYaml .Values.deploymentLabels | trim | indent 6 }}
       {{- end }}
       {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | trim | indent 6 }}


### PR DESCRIPTION
`deploymentLabels` should be intended exactly like pod labels.

If I understood correctly, Values should look like this:
```yaml
  deploymentLabels:
    app-group: "metabase"
    app.kubernetes.io/name: "metabase"
    foo: bar
```

With the current template this results in an invalid pdb file