### PR TITLE
Upgrade metabase version to 0.52.6

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.17.2
-appVersion: v0.51.1
+version: 2.18.0
+appVersion: v0.52.6.x
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
Metabase latest release: [v0.52.6](https://github.com/metabase/metabase/releases/tag/v0.52.6)

(Used the `v0.52.6.x` Docker image tag, because the Github release references it.)