### PR TITLE
change the obj to map

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.18.0
+version: 2.18.1
 appVersion: v0.52.6.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -302,7 +302,7 @@ awsEKS:
     #   - sg-abc123
     #   - sg-xyz456
 
-extraEnv: {}
+extraEnv: []
 #  - name: MB_CHECK_FOR_UPDATES
 #    value: false
 #  - name: MB_ADMIN_EMAIL


### PR DESCRIPTION
This is small and probably doesn't cause any issues but the extraEnv is a list but the default has it as a map