### PR TITLE
Upgrade Metabase version to v0.53.17

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.18.1
-appVersion: v0.52.6.x
+version: 2.19.0
+appVersion: v0.53.17.x
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
This PR upgrades to the Metabase v0.53 series ([Docker tag](https://hub.docker.com/layers/metabase/metabase/v0.53.17.x/images/sha256-77cc2712eb97a7b74a352d215af7b9b7a6e3cab85b59bd918d324e8a361435c7) `v0.53.17.x` specifically):
https://github.com/metabase/metabase/releases/tag/v0.53.17

I will make a follow-up PR that will introduce the bump to the latest v0.54 release.
Including both versions separately provides a clear upgrade path and historical context for future reference.