### PR TITLE
Upgrade Metabase version to v0.54.11

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.19.0
-appVersion: v0.53.17.x
+version: 2.20.0
+appVersion: v0.54.11.x
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
After reviewing the values.yaml file and checking the Metabase release
notes between v0.53.17.x and v0.54.11.x, I believe that there are no
breaking changes in the Helm chart values format.

The main changes in v0.54.x were focused on features and improvements
rather than structural changes to the configuration.
