### PR TITLE
feat(metabase): add persistence configuration for H2 database and upd…

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.20.0
+version: 2.21.0
 appVersion: v0.54.11.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -56,3 +56,37 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "metabase.labels" -}}
+helm.sh/chart: {{ include "metabase.chart" . }}
+{{ include "metabase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metabase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metabase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metabase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the namespace name
+*/}}
+{{- define "metabase.namespace" -}}
+{{- .Release.Namespace -}}
+{{- end -}}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -257,8 +257,12 @@ spec:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          {{- if or .Values.log4jProperties .Values.log4j2XML (ne (len .Values.extraVolumeMounts) 0) }}
+          {{- if or .Values.log4jProperties .Values.log4j2XML (ne (len .Values.extraVolumeMounts) 0) .Values.database.persistence.enabled }}
           volumeMounts:
+            {{- if .Values.database.persistence.enabled }}
+            - name: {{ template "metabase.fullname" . }}-database
+              mountPath: /metabase.db/
+            {{- end }}
             {{- if or .Values.log4jProperties .Values.log4j2XML }}
             - name: config
               mountPath: /tmp/conf/
@@ -341,6 +345,11 @@ spec:
       serviceAccountName: {{ template "metabase.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       volumes:
+        {{- if .Values.database.persistence.enabled }}
+        - name: {{ template "metabase.fullname" . }}-database
+          persistentVolumeClaim:
+            claimName: {{ template "metabase.fullname" . }}-database
+        {{- end }}
         {{- if or .Values.log4jProperties .Values.log4j2XML }}
         - name: config
           configMap:

--- a/charts/metabase/templates/pvc.yaml
+++ b/charts/metabase/templates/pvc.yaml
@@ -1,0 +1,36 @@
+{{- if and  .Values.database.persistence.enabled (not .Values.database.persistence.existingClaim) (eq .Values.database.persistence.type "pvc")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "metabase.fullname" . }}-database
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+    {{- with .Values.database.persistence.extraPvcLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.database.persistence.annotations  }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.persistence.finalizers  }}
+  finalizers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.database.persistence.size | quote }}
+  {{- if and (.Values.database.persistence.lookupVolumeName) (lookup "v1" "PersistentVolumeClaim" (include "metabase.namespace" .) (include "metabase.fullname" .)) }}
+  volumeName: {{ (lookup "v1" "PersistentVolumeClaim" (include "metabase.namespace" .) (include "metabase.fullname" .)).spec.volumeName }}
+  {{- end }}
+  {{- with .Values.database.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.database.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -359,4 +359,5 @@ sidecars: []
   #       cpu: 10m
   #   command: ["/bin/sh"]
   #   args: ["-c", "while true; do echo hello; sleep 10;done"]
-  
+
+

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -359,3 +359,4 @@ sidecars: []
   #       cpu: 10m
   #   command: ["/bin/sh"]
   #   args: ["-c", "while true; do echo hello; sleep 10;done"]
+  

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -359,5 +359,3 @@ sidecars: []
   #       cpu: 10m
   #   command: ["/bin/sh"]
   #   args: ["-c", "while true; do echo hello; sleep 10;done"]
-
-

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -67,7 +67,7 @@ database:
   # if h2 is used, the persistentVolume and pvc are used to store the database. Only for non-production environments.
   persistence:
     type: pvc
-    enabled: true
+    enabled: false
     # storageClassName: default
     ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
     volumeName: ""

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -64,6 +64,31 @@ jetty:
 database:
   # Database type (h2 / mysql / postgres), default: h2
   type: h2
+  # if h2 is used, the persistentVolume and pvc are used to store the database. Only for non-production environments.
+  persistence:
+    type: pvc
+    enabled: true
+    # storageClassName: default
+    ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
+    volumeName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    # annotations: {}
+    finalizers:
+      - kubernetes.io/pvc-protection
+    # selectorLabels: {}
+    ## Sub-directory of the PV to mount. Can be templated.
+    # subPath: ""
+    ## Name of an existing PVC. Can be templated.
+    # existingClaim:
+    ## Extra labels to apply to a PVC.
+    extraPvcLabels: {}
+    disableWarning: false
+
+    ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
+    ## the current value of 'spec.volumeName' and incorporate it into the template.
+    lookupVolumeName: true
   ## Specify file to store H2 database.  You will also have to back this with a volume (cf. extraVolume and extraVolumeMounts)!
   # file:
   # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >>


### PR DESCRIPTION

- Introduced persistence options for H2 database in values.yaml, enabling PVC storage.
- Updated ingress configuration to enable access and specify ALB annotations.
- Added common and selector labels in _helpers.tpl for better resource management.
- Created a new PVC template for database persistence management.