### PR TITLE
[metabase] introduce startupProbe

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.22.2
+version: 2.23.0
 appVersion: v0.56.2.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -103,10 +103,13 @@ The following table lists the configurable parameters of the Metabase chart and 
 | extraInitContainers                             | Additional init containers e.g. to download plugins                        | []                |
 | extraVolumes                                    | Additional server volumes                                                  | []                |
 | extraVolumeMounts                               | Additional server volumeMounts                                             | []                |
-| livenessProbe.initialDelaySeconds               | Delay before liveness probe is initiated                                   | 120               |
+| startupProbe.timeoutSeconds                     | When the probe times out                                                   | 3                 |
+| startupProbe.failureThreshold                   | Minimum consecutive failures for the probe                                 | 60                |
+| startupProbe.periodSeconds                      | How often to perform the probe                                             | 5                 |
+| livenessProbe.initialDelaySeconds               | Delay before liveness probe is initiated                                   | 5                 |
 | livenessProbe.timeoutSeconds                    | When the probe times out                                                   | 30                |
 | livenessProbe.failureThreshold                  | Minimum consecutive failures for the probe                                 | 6                 |
-| readinessProbe.initialDelaySeconds              | Delay before readiness probe is initiated                                  | 30                |
+| readinessProbe.initialDelaySeconds              | Delay before readiness probe is initiated                                  | 5                 |
 | readinessProbe.timeoutSeconds                   | When the probe times out                                                   | 3                 |
 | readinessProbe.periodSeconds                    | How often to perform the probe                                             | 5                 |
 | service.type                                    | ClusterIP, NodePort, or LoadBalancer                                       | ClusterIP         |

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -243,6 +243,13 @@ spec:
           securityContext:
           {{- .Values.securityContext | toYaml | nindent 12 }}
           {{- end }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -175,15 +175,21 @@ extraVolumes: []
 #  - name: plugins
 #    emptyDir: {}
 
+startupProbe:
+  path: /api/health
+  timeoutSeconds: 3
+  failureThreshold: 60
+  periodSeconds: 5
+
 livenessProbe:
   path: /api/health
-  initialDelaySeconds: 120
+  initialDelaySeconds: 5
   timeoutSeconds: 30
   failureThreshold: 6
 
 readinessProbe:
   path: /api/health
-  initialDelaySeconds: 30
+  initialDelaySeconds: 5
   timeoutSeconds: 3
   periodSeconds: 5
 


### PR DESCRIPTION
Introduces a startupProbe with a default of 5 minutes maximum total wait (60 * 5 s = 300s).

Decreased initialDelay of liveness-/readinessProbes as those now only execute after the startupProbe was successful.

closes #124 