### PR TITLE
[charts/metabase] feat: add Kubernetes Gateway API HTTPRoute support

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.24.4
+version: 2.25.0
 appVersion: v0.56.20.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if .Values.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.httpRoute.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+  {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httpRoute.rules }}
+  {{- range .Values.httpRoute.rules }}
+    - matches:
+      {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+          {{- if .headers }}
+          headers:
+          {{- range .headers }}
+            - name: {{ .name }}
+              value: {{ .value }}
+              {{- if .type }}
+              type: {{ .type }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+      {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $.Values.httpRoute.servicePort | default $.Values.service.port | default 80 }}
+          {{- if .weight }}
+          weight: {{ .weight }}
+          {{- end }}
+  {{- end }}
+  {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.path | default "/" }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ .Values.httpRoute.servicePort | default .Values.service.port | default 80 }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -265,6 +265,7 @@ ingress:
     #   hosts:
     #     - metabase.domain.com
 
+# Note: This is the Openshift route
 route:
   enabled: false
   labels:
@@ -300,6 +301,54 @@ route:
 # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
 # strategy:
 #   type: "Recreate"
+
+# -- Kubernetes Gateway API HTTPRoute
+# Use it with a Gateway API implementation (e.g. Envoy Gateway, Istio, Cilium, etc.)
+# Ref: https://gateway-api.sigs.k8s.io/
+httpRoute:
+  enabled: false
+ 
+  ## Labels to add to the HTTPRoute resource
+  labels: {}
+ 
+  ## Annotations to add to the HTTPRoute resource
+  annotations: {}
+ 
+  ## Parent Gateway reference(s) that this HTTPRoute attaches to.
+  ## The Gateway must already exist and have a matching listener.
+  ## TLS termination is configured on the Gateway, not here.
+  parentRefs:
+    - name: ""
+      # namespace: gateway-namespace
+      # sectionName: https
+ 
+  ## Hostnames to match. Must align with the Gateway listener's hostname/certificate.
+  ## Example:
+  ##   hostnames:
+  ##     - metabase.example.com
+  hostnames: []
+ 
+  ## Simple path-based routing (used when 'rules' is not set)
+  path: "/"
+ 
+  ## Override the backend service port (defaults to .Values.service.port)
+  # servicePort: 80
+ 
+  ## Advanced: define custom routing rules.
+  ## When set, 'path' above is ignored. Each rule gets the service backend automatically.
+  ## Example:
+  ##   rules:
+  ##     - matches:
+  ##         - path:
+  ##             type: PathPrefix
+  ##             value: /
+  ##       filters:
+  ##         - type: RequestHeaderModifier
+  ##           requestHeaderModifier:
+  ##             set:
+  ##               - name: X-Forwarded-Proto
+  ##                 value: https
+  # rules: []
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -307,13 +307,13 @@ route:
 # Ref: https://gateway-api.sigs.k8s.io/
 httpRoute:
   enabled: false
- 
+
   ## Labels to add to the HTTPRoute resource
   labels: {}
- 
+
   ## Annotations to add to the HTTPRoute resource
   annotations: {}
- 
+
   ## Parent Gateway reference(s) that this HTTPRoute attaches to.
   ## The Gateway must already exist and have a matching listener.
   ## TLS termination is configured on the Gateway, not here.
@@ -321,19 +321,19 @@ httpRoute:
     - name: ""
       # namespace: gateway-namespace
       # sectionName: https
- 
+
   ## Hostnames to match. Must align with the Gateway listener's hostname/certificate.
   ## Example:
   ##   hostnames:
   ##     - metabase.example.com
   hostnames: []
- 
+
   ## Simple path-based routing (used when 'rules' is not set)
   path: "/"
- 
+
   ## Override the backend service port (defaults to .Values.service.port)
   # servicePort: 80
- 
+
   ## Advanced: define custom routing rules.
   ## When set, 'path' above is ignored. Each rule gets the service backend automatically.
   ## Example:


### PR DESCRIPTION
Adds support for Gateway API HTTPRoute as an alternative to the classic Ingress resource.

Cool project by the way! 👋

With the wave of migrations away from nginx ingress (we've been through that pain too), Gateway API is rising. This adds HTTPRoute support so users of the chart can opt for that as well.

Usage is straightforward - enable it and point it at your Gateway:
```
httpRoute:
  enabled: true
  parentRefs:
    - name: my-gateway
      namespace: gateway-namespace
      sectionName: https
  hostnames:
    - metabase.example.com
```
For more advanced cases, you can define custom routing rules directly (header matching, filters, etc.) using httpRoute.rules.

Also snuck in a comment above the existing route: block to clarify that one is the OpenShift-specific Route as it was a bit ambiguous sitting next to this new one.