### PR TITLE
feat(metabase): bump metabase to v0.60.3

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.27.1
-appVersion: v0.60.2.x
+version: 2.27.2
+appVersion: v0.60.3.x
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
## Summary

Bumps the Metabase chart appVersion from `v0.60.2.x` to `v0.60.3.x` and the chart version from `2.27.1` to `2.27.2`.

