### PR TITLE
[charts/metabase] Allow external managed HPA

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.27.2
+version: 2.27.3
 appVersion: v0.60.3.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/hpa.yaml
+++ b/charts/metabase/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hpa.enabled }}
+{{- if and .Values.hpa.enabled (not .Values.hpa.external) }}
 apiVersion: {{ template "hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -2,6 +2,10 @@ replicaCount: 1
 
 hpa:
   enabled: false
+  # If external: false, the HPA will be managed by the chart
+  # If external: true, the HPA will not be created by the chart
+  # Useful for external HPA controllers such as KEDA.
+  external: false
   minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
### Purpose

Allow external HPA controllers (e.g., KEDA) to manage autoscaling for Metabase.

When `hpa.external: true`, the chart skips creating its own HorizontalPodAutoscaler, avoiding conflicts with external autoscalers while still allowing users to set hpa.enabled: true for any related configuration.

### Changes

- Add `hpa.external` flag (`default: false` for backward compatibility)
- HPA resource is only created when `hpa.enabled=true` AND `hpa.external=false`

### Testing

```bash
# Test 1: HPA disabled (default) - should NOT create HPA
$ helm template test charts/metabase --set hpa.enabled=false | grep "kind: HorizontalPodAutoscaler"
# (no output - correct)

# Test 2: HPA enabled, external=false - should create HPA
$ helm template test charts/metabase --set hpa.enabled=true,hpa.external=false | grep -A5 "kind: HorizontalPodAutoscaler"
kind: HorizontalPodAutoscaler
metadata:
  name: test-metabase
spec:
  scaleTargetRef:
    apiVersion: apps/v1

# Test 3: HPA enabled, hpa.external not passed - should create HPA
$ helm template test charts/metabase --set hpa.enabled=true | grep -A5 "kind: HorizontalPodAutoscaler"
kind: HorizontalPodAutoscaler
metadata:
  name: test-metabase
spec:
  scaleTargetRef:
    apiVersion: apps/v1
   
# Test 4: HPA enabled, external=true - should NOT create HPA (for KEDA etc.)
$ helm template test charts/metabase --set hpa.enabled=true,hpa.external=true | grep "kind: HorizontalPodAutoscaler"
# (no output - correct)
```

This demonstrates backward compatibility and the new external HPA behavior (test 3).