### PR TITLE
feat(metabase): bump metabase to v0.61.1

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.27.3
-appVersion: v0.60.3.x
+version: 2.27.4
+appVersion: v0.61.1.x
 maintainers:
   - name: pmint93
     email: phamminhthanh69@gmail.com


### PR DESCRIPTION
Bumps the Metabase chart to **appVersion `v0.61.1`** (chart `2.27.3` → `2.27.4`), following the same pattern as #181 and #182.

Release notes: https://www.metabase.com/releases/metabase-61
