### PR TITLE
[charts/metabase] feat: allow to set ip_adress_types flag in the cloud sql proxy command

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,7 +3,7 @@ description:
   The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 2.27.4
+version: 2.27.5
 appVersion: v0.61.1.x
 maintainers:
   - name: pmint93

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -290,6 +290,9 @@ spec:
             - "-structured_logs"
             - "-use_http_health_check"
             - "-enable_iam_login"
+            {{- if .Values.database.googleCloudSQL.ipAddressTypes }}
+            - "-ip_address_types={{ .Values.database.googleCloudSQL.ipAddressTypes }}"
+            {{- end }}
           securityContext:
           {{- .Values.database.googleCloudSQL.securityContext | toYaml | nindent 12 }}
           livenessProbe:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -127,6 +127,9 @@ database:
     ## example format: $project:$region:$instance=tcp:$port
     ## Each connection must have a unique TCP port.
     instanceConnectionNames: []
+    ## IP address types for Cloud SQL (e.g. PRIVATE,PUBLIC)
+    ipAddressTypes: ""
+    #
     ## Option to use a specific version and image of the *Cloud SQL Auth proxy* sidecar image.
     ## ref: https://console.cloud.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy
     # sidecarImage: gcr.io/cloudsql-docker/gce-proxy


### PR DESCRIPTION
## Purpose
Allow to set the flag `ip_address_types=PRIVATE` to the Cloud SQL proxy.

## Changes
Add `database.googleCloudSQL.ipAddressTypes` value (default: "" for backward compatibility)

## Testing
```
# TEST 1: Default (empty) - flag should NOT appear
$ helm template test charts/metabase \
  --set 'database.googleCloudSQL.instanceConnectionNames[0]=project:region:instance=tcp:5432'

Result:
  - "/cloud_sql_proxy"
  - "-instances=project:region:instance=tcp:5432"
  - "-term_timeout=10s"
  - "-structured_logs"
  - "-use_http_health_check"
  - "-enable_iam_login"
  ✓ NO ip_address_types flag (CORRECT)


# TEST 2: ipAddressTypes=PRIVATE
$ helm template test charts/metabase \
  --set 'database.googleCloudSQL.instanceConnectionNames[0]=project:region:instance=tcp:5432' \
  --set 'database.googleCloudSQL.ipAddressTypes=PRIVATE'

Result:
  - "/cloud_sql_proxy"
  - "-instances=project:region:instance=tcp:5432"
  - "-term_timeout=10s"
  - "-structured_logs"
  - "-use_http_health_check"
  - "-enable_iam_login"
  - "-ip_address_types=PRIVATE"
  ✓ Flag present with PRIVATE value (CORRECT)


# TEST 3: ipAddressTypes=PUBLIC
$ helm template test charts/metabase \
  --set 'database.googleCloudSQL.instanceConnectionNames[0]=project:region:instance=tcp:5432' \
  --set 'database.googleCloudSQL.ipAddressTypes=PUBLIC'

Result:
  - "/cloud_sql_proxy"
  - "-instances=project:region:instance=tcp:5432"
  - "-term_timeout=10s"
  - "-structured_logs"
  - "-use_http_health_check"
  - "-enable_iam_login"
  - "-ip_address_types=PUBLIC"
  ✓ Flag present with PUBLIC value (CORRECT)
```

This demonstrates backward compatibility and the new value behavior.


#186 